### PR TITLE
Add Grid three-column story examples

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@onsvisual/svelte-components",
-	"version": "1.1.55",
+	"version": "1.1.56",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@onsvisual/svelte-components",
-			"version": "1.1.55",
+			"version": "1.1.56",
 			"devDependencies": {
 				"@chromatic-com/storybook": "^5.2.1",
 				"@eslint/compat": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@onsvisual/svelte-components",
-	"version": "1.1.55",
+	"version": "1.1.56",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "npm run build:package && npm run build:docs",

--- a/src/lib/components/Grid/Grid.stories.svelte
+++ b/src/lib/components/Grid/Grid.stories.svelte
@@ -33,6 +33,22 @@
 	</Grid>
 {/snippet}
 
+{#snippet threeColumnsTemplate(args)}
+	<Grid colWidth="medium" {...args}>
+		<GridCell><div class="grid-cell">Grid cell one</div></GridCell>
+		<GridCell><div class="grid-cell">Grid cell two</div></GridCell>
+		<GridCell><div class="grid-cell">Grid cell three</div></GridCell>
+	</Grid>
+{/snippet}
+
+{#snippet threeColumnsClassTemplate(args)}
+	<Grid {...args}>
+		<GridCell cls="ons-col-4@m"><div class="grid-cell">Grid cell one</div></GridCell>
+		<GridCell cls="ons-col-4@m"><div class="grid-cell">Grid cell two</div></GridCell>
+		<GridCell cls="ons-col-4@m"><div class="grid-cell">Grid cell three</div></GridCell>
+	</Grid>
+{/snippet}
+
 <Story name="Default" args={{}} {template} />
 
 <Story name="Wide columns" args={{ colWidth: "wide" }} {template} />
@@ -40,6 +56,10 @@
 <Story name="Narrow columns" args={{ colWidth: "narrow" }} {template} />
 
 <Story name="Full width columns" args={{ colWidth: "full" }} {template} />
+
+<Story name="Three columns with medium column width" args={{}} template={threeColumnsTemplate} />
+
+<Story name="Three columns with GridCell class override" args={{}} template={threeColumnsClassTemplate} />
 
 <style>
 	.grid-cell {

--- a/src/lib/components/Grid/Grid.stories.svelte
+++ b/src/lib/components/Grid/Grid.stories.svelte
@@ -33,16 +33,16 @@
 	</Grid>
 {/snippet}
 
-{#snippet threeColumnsTemplate(args)}
-	<Grid colWidth="medium" {...args}>
+{#snippet threeColumnsTemplate()}
+	<Grid colWidth="medium">
 		<GridCell><div class="grid-cell">Grid cell one</div></GridCell>
 		<GridCell><div class="grid-cell">Grid cell two</div></GridCell>
 		<GridCell><div class="grid-cell">Grid cell three</div></GridCell>
 	</Grid>
 {/snippet}
 
-{#snippet threeColumnsClassTemplate(args)}
-	<Grid {...args}>
+{#snippet threeColumnsClassTemplate()}
+	<Grid>
 		<GridCell cls="ons-col-4@m"><div class="grid-cell">Grid cell one</div></GridCell>
 		<GridCell cls="ons-col-4@m"><div class="grid-cell">Grid cell two</div></GridCell>
 		<GridCell cls="ons-col-4@m"><div class="grid-cell">Grid cell three</div></GridCell>


### PR DESCRIPTION
This adds two explicit Storybook examples for three-column Grid layouts so the supported patterns are easy to find and compare when using `Grid` and `GridCell`.

## What changed
- add a story that uses `Grid colWidth="medium"` to produce a three-column layout at large breakpoints
- add a story that uses `GridCell cls="ons-col-4@m"` to show an explicit 12-column override
- bump the package version from `1.1.55` to `1.1.56`

## Notes
- the new examples are static stories so they do not introduce extra snippet `args` diagnostics beyond the repo's existing baseline
- repo-wide `npm run check` still reports pre-existing diagnostics in other Storybook files